### PR TITLE
Adds filter to $post_status

### DIFF
--- a/class-post-by-email.php
+++ b/class-post-by-email.php
@@ -270,6 +270,9 @@ class Post_By_Email {
 				$post_status = 'pending';
 			}
 
+			//Give Post-By-Email extending plugins the option of setting the post status
+			$post_status = apply_filters( 'wp_mail_post_status', $post_status );
+
 
 			/* Date */
 			$ddate_U = $this->get_message_date( $headers );


### PR DESCRIPTION
Currently the post status is limited to either publish or pending, depending on whether the sender's email address is linked to an existing account.

An extending plugin might want to hook in to 'publish_phone' to do stuff to the post before publishing, eg. add custom fields based on the message title or content.
