### PR TITLE
Sets $post_author to 0 in stead of 1 if no author found

### DIFF
--- a/class-post-by-email.php
+++ b/class-post-by-email.php
@@ -285,7 +285,7 @@ class Post_By_Email {
 			}
 			else {
 				// use admin if no author found
-				$post_author = 1;
+				$post_author = 0;
 				$post_status = 'pending';
 			}
 


### PR DESCRIPTION
The user is set to 1 when a user with a corresponding $from_email is not found. A user with that ID might not exist. Setting it to 0 prevents a php notice when calling wp_dropdown_users(), eg. in the 'Author' meta box.
