### PR TITLE
Import inline images and use wp_handle_sideload() for image importing

### DIFF
--- a/class-post-by-email.php
+++ b/class-post-by-email.php
@@ -726,7 +726,7 @@ class Post_By_Email {
 		foreach ( $map as $key => $value ) {
 			$p = $part->getPart( $key );
 
-			if ( 'attachment' == $p->getDisposition() ) {
+			if ( 'attachment' == $p->getDisposition() || ( 'inline' == $p->getDisposition() && 'image' == $p->getPrimaryType() ) ) {
 				$mime_id = $key;
 				$filename = sanitize_file_name( $p->getName() );
 				$filetype = $p->getType();
@@ -745,33 +745,51 @@ class Post_By_Email {
 
 				$message = $list2->first();
 
-				$image_data = $message->getBodyPart( $mime_id );
-				$image_data_decoded = base64_decode( $image_data );
-
 				$upload_dir = wp_upload_dir();
 				$directory = $upload_dir['basedir'] . $upload_dir['subdir'];
 
-				wp_mkdir_p( $directory );
-				file_put_contents( $directory . '/' . $filename, $image_data_decoded );
+				$image_data = $message->getBodyPart( $mime_id );
+				$image_data_decoded = base64_decode( $image_data );
 
-				// add attachment to the post
-				$attachment_args = array(
-					'post_title' => $filename,
-					'post_content' => '',
-					'post_status' => 'publish',
-					'post_mime_type' => $filetype,
+				$tmp_file      = tmpfile();
+				$meta_data     = stream_get_meta_data( $tmp_file );
+				$written_bytes = fwrite( $tmp_file, $image_data_decoded );
+				fseek( $tmp_file, 0 );
+
+				$file = array(
+					'name'     => $filename,
+					'tmp_name' => $meta_data['uri'],
+					'type'     => $value,
+					'size'     => $written_bytes,
 				);
 
-				$attachment_id = wp_insert_attachment( $attachment_args, $directory . '/' . $filename, $postID );
-				$attachment_metadata = wp_generate_attachment_metadata( $attachment_id, $directory . '/' . $filename );
-				wp_update_attachment_metadata( $attachment_id, $attachment_metadata );
-				$attachment_count++;
+				$new_file = wp_handle_sideload( $file, array( 'test_form' => false ) );
 
-				// make the first image attachment the featured image
-				$image_types = array( 'image/jpeg', 'image/jpg', 'image/png', 'image/gif' );
-				if ( false == $post_thumbnail && in_array( $filetype, $image_types ) ) {
-					set_post_thumbnail( $postID, $attachment_id );
-					$post_thumbnail = true;
+				// Delete the temp file
+				fclose( $tmp_file );
+
+				if ( $new_file && ! is_wp_error( $new_file ) && ! isset( $new_file['error'] ) ) {
+					$filename = basename( $new_file['file'] );
+
+					// add attachment to the post
+					$attachment_args = array(
+						'post_title' => $filename,
+						'post_content' => '',
+						'post_status' => 'publish',
+						'post_mime_type' => $filetype,
+					);
+
+					$attachment_id = wp_insert_attachment( $attachment_args, $new_file['file'], $postID );
+					$attachment_metadata = wp_generate_attachment_metadata( $attachment_id, $new_file['file'] );
+					wp_update_attachment_metadata( $attachment_id, $attachment_metadata );
+					$attachment_count++;
+
+					// make the first image attachment the featured image
+					$image_types = array( 'image/jpeg', 'image/jpg', 'image/png', 'image/gif' );
+					if ( false == $post_thumbnail && in_array( $filetype, $image_types ) ) {
+						set_post_thumbnail( $postID, $attachment_id );
+						$post_thumbnail = true;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Hi there, 

This should resolve #5 ( see line 729 - this is where we check to see if the part is an inlined image ). 

In addition to that, I've also switched to using `wp_handle_sideload()` as the means for moving the image to the uploads directory, since certain plugins(in my case it was the Image Watermark plugin) need to hook to the `wp_handle_upload` filter. 

At this point inlined images will only be imported to the media gallery, but the `<img />` tags will still have the incorrect `src="cid:...` attributes. I have fixed that as well and can add it to this pull request, or to a different one - depending on which one you'd prefer me to do :smiley: 

I know that you're busy too, so let me know if there's anything that I can do to make it easier for you to merge this. 

Note: in #5 we talked about updating the Horde library, but I tested with the version that is currently in master and it works just fine.

This is what happens with inlined images at the moment:
![Inlined images with cid](http://screens.paiyakdev.com/Screenshot-at-2015-02-17_13:10:47.png)


With the exception that they now show in the gallery:
![Images are imported properly](http://screens.paiyakdev.com/Screenshot-at-2015-02-17_13:12:06.png)

Nikola